### PR TITLE
add window view

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -299,7 +299,7 @@ def extract_windows(signal, sfreq, winsize, stepsize=None, axis=-1):
                      If None, defaults to 1
     :param axis:     on which axis to extract the windows
     """ 
-    if stepsize is None: stepsize = 1
+    if stepsize is None: stepsize = 1/sfreq
     stepsize *= sfreq  # convert to sample space
     winsize *= sfreq  # convert to sample space
     assert signal.shape[axis]>=winsize, 'signal is shorter than window size'


### PR DESCRIPTION
Here's the function to extract windowed views from signals

you can use it like this

```python
sfreq = 1000
signal = np.random.rand(144, 306, sfreq*4)  # signal.shape = (144, 306, 4000)
# extract windows of 500 ms from the signal
# each window start is 0.05 seconds apart from the next window
windows = extract_windows(signal, sfreq=1000, winsize=0.5, stepsize=0.05)
# windows.shape = (71, 144, 306, 500)
# there are now 71 such windows now. 
# Window 0 starts at t=0 (0.0s) and is 500ms long.
# Window 1 starts at t=1 (0.05s) and is 500ms long
# ...

```

You can use them now to e.g. extract frequency information via FFT

```python
import scipy
windows_power = []

# this loop can for sure be paralellized and also should be a function with parameters and not a loop
for win in tqdm(windows):   
    # convert to frequency domain via rfft (we don't need the imaginary part)
    w = scipy.fftpack.rfft(win, axis=-1)
    freqs = scipy.fftpack.rfftfreq(w.shape[-1], d=1/sfreq)
    # w.shape = (144, 306, 500)
    # freqs = [0, 2, 4, ..., 500] freqs belonging to each index of w
    power = np.abs(w)** 2 / (len(w[-1]) * sfreq)  # convert to spectral power
    # e.g. w[0, 4, 2] = power of epoch 0, channel 4 for frequency bin 4 Hz
    # now you can use these to calculate brain bands, e.g.
    alpha = [8, 14]
    alpha_idx1 = np.argmax(freqs>alpha[0])
    alpha_idx2 = np.argmax(freqs>alpha[1])
    alpha_power = power[:,:, alpha_idx1:alpha_idx2].mean(-1)
    # alpha_power .shape = (144, 306), 
    # for each epoch, for each channel one alpha power value
    windows_power += [alpha_power]  # add alpha power values of this window to list

# just for the fun of it, plot mean alpha power over time for each channel
# there should a streak of occipital channels showing higher alpha
plt.imshow(np.mean(windows_power, axis=1).T, aspect='auto')
plt.xlabel('timestep of window')
plt.ylabel('channel number')
```

![image](https://github.com/CIMH-Clinical-Psychology/MasterThesisVeraKluetz/assets/14980558/0b5857cb-bd3e-4647-ba2f-d155dceb64a0)
